### PR TITLE
add http client header item so Tiled acquisition cluster is used

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -67,9 +67,11 @@ class TiledInserter:
 tiled_writing_client = from_profile(
     "nsls2", api_key=os.environ["TILED_BLUESKY_WRITING_API_KEY_XPD"]
 )["xpd"]["raw"]
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 tiled_inserter = TiledInserter(tiled_writing_client)
 if not is_re_worker_active():
     c = tiled_reading_client = from_profile("nsls2")["xpd"]["raw"]
+    c.context.http_client.headers['tiled-qos'] = 'acquisition'
     db = Broker(c)
 
 nslsii.configure_base(

--- a/startup/25-QEPro.py
+++ b/startup/25-QEPro.py
@@ -547,6 +547,7 @@ try:
     from tiled.client import from_profile
     # tiled_client = from_profile("xpd-ldrd20-31")
     tiled_client = from_profile("xpd")
+    tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 except CannotPrompt:
     print("Tiled client cannot prompt for login. QEPro export to csv will not work.")
 except (NameError, ModuleNotFoundError):

--- a/startup/32-data_export.py
+++ b/startup/32-data_export.py
@@ -172,6 +172,7 @@ def read_qepro_by_stream(uid, stream_name='primary', data_agent='tiled'):
             from tiled.client import from_profile
             # tiled_client = from_profile("xpd-ldrd20-31")
             tiled_client = from_profile("xpd")
+            tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
             
         run = tiled_client[uid]
         meta = run.metadata
@@ -490,6 +491,7 @@ def read_qepro_from_tiled(uid):
         from tiled.client import from_profile
         # tiled_client = from_profile("xpd-ldrd20-31")
         tiled_client = from_profile("xpd")  
+        tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
     
     run = tiled_client[uid]
     ds = run.primary.read()


### PR DESCRIPTION
Add item that directs use of Tiled acquisition cluster to be used while acquiring data. Tiled clients from Prefect workflows, Jupyter notebooks, and other sources will be isolated from the acquisition cluster, ensuring data acquisition is not negatively affected by non-acquisition Tiled requests.